### PR TITLE
Replace yarn calls with npm equivalents

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "scripts": {
     "start": "tsdx watch",
-    "build": "node ./scripts/prepare.js && yarn type-check && tsdx build --transpileOnly && node ./scripts/copyData.js",
+    "build": "node ./scripts/prepare.js && npm run type-check && tsdx build --transpileOnly && node ./scripts/copyData.js",
     "type-check": "tsc --noEmit --incremental --pretty --project tsconfig.json",
     "test": "tsdx test --passWithNoTests",
     "lint": "eslint ./src --ext .ts,.tsx",
-    "prepare": "yarn type-check && tsdx build --transpileOnly",
+    "prepare": "npm run type-check && tsdx build --transpileOnly",
     "size": "size-limit",
     "analyze": "size-limit --why",
     "storybook": "start-storybook -p 6006",
@@ -41,7 +41,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint"
+      "pre-commit": "npm run lint"
     }
   },
   "prettier": {


### PR DESCRIPTION
The yarn calls were breaking on the build server